### PR TITLE
Modified ROOT_URL to include api endpoint

### DIFF
--- a/client/actions/index.js
+++ b/client/actions/index.js
@@ -19,7 +19,7 @@ export const AUTH_USER = 'auth_user';
 export const UNAUTH_USER = 'unauth_user';
 export const INVENTORY_ERROR = 'inventory_error';
 
-const ROOT_URL = __BASEURL__;
+const ROOT_URL = `${__BASEURL__}/api`;
 
 const getAxiosConfig = () => {
   const token = localStorage.getItem('token');


### PR DESCRIPTION
sorry I didn't catch this earlier - the `/api` was omitted from the last PR causing 404s everywhere

_manually tested on Node 5_
